### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,19 +2,17 @@
 requires = ["sip >=6"]
 build-backend = "sipbuild.api"
 
-[project]
+[tool.poetry]
 name = "pywpsrpc"
 version = "2.3.9"
 description = "Python bindings for the WPS Office RPC"
 readme = "README.md"
-authors = [
-    { name = "Weitian Leung", email = "weitianleung@gmail.com" }
-]
+authors = ["Weitian Leung <weitianleung@gmail.com>"]
+
 license = "MIT"
 homepage = "https://github.com/timxx/pywpsrpc"
 keywords = ["WPS Office", "RPC", "Python bindings"]
-platform = "Linux"
-tool.sip.project.sdist-excludes = [
+exclude = [
     ".gitignore", ".travis.yml", "*.tar.gz",
     ".git/*", ".git/*/*", ".git/*/*/*", ".git/*/*/*/*",
     ".git/*/*/*/*/*", ".git/*/*/*/*/*/*", ".git/*/*/*/*/*/*/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,21 +2,22 @@
 requires = ["sip >=6"]
 build-backend = "sipbuild.api"
 
-[tool.sip.metadata]
+[project]
 name = "pywpsrpc"
 version = "2.3.9"
-summary = "Python bindings for the WPS Office RPC"
-home-page = "https://github.com/timxx/pywpsrpc"
-author = "Weitian Leung"
-author-email = "weitianleung@gmail.com"
+description = "Python bindings for the WPS Office RPC"
+readme = "README.md"
+authors = [
+    { name = "Weitian Leung", email = "weitianleung@gmail.com" }
+]
 license = "MIT"
-description-file = "README.md"
-description-content-type = "text/markdown"
+homepage = "https://github.com/timxx/pywpsrpc"
+keywords = ["WPS Office", "RPC", "Python bindings"]
 platform = "Linux"
-
-[tool.sip.project]
-sdist-excludes = [".gitignore", ".travis.yml", "*.tar.gz",
+tool.sip.project.sdist-excludes = [
+    ".gitignore", ".travis.yml", "*.tar.gz",
     ".git/*", ".git/*/*", ".git/*/*/*", ".git/*/*/*/*",
     ".git/*/*/*/*/*", ".git/*/*/*/*/*/*", ".git/*/*/*/*/*/*/*",
     ".github/*/*", ".vscode/*", ".gitmodules", "wpsrpc-sdk/.git",
-    "build/*", "build/*/*", "build/*/*/*", "build/.*"]
+    "build/*", "build/*/*", "build/*/*/*", "build/.*"
+]


### PR DESCRIPTION
[tool.sip.metadata]' to specify the project metadata is deprecated and will be removed in SIP v7.0.0, use '[project]' instead
  ABI v12.0 is deprecated and will be removed in SIP v7.0.0, use v12.9 or later instead